### PR TITLE
增加缺少的依赖，修复svgIcon的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "prism-code-editor": "^3.4.0-beta.1",
     "prismjs": "^1.29.0",
     "prosemirror-docx": "^0.2.0",
+    "prosemirror-transform": "^1.10.0",
     "qrcode-svg": "^1.1.0",
     "svg64": "^2.0.0",
     "vue-esign": "^1.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ dependencies:
   prosemirror-docx:
     specifier: ^0.2.0
     version: 0.2.0
+  prosemirror-transform:
+    specifier: ^1.10.0
+    version: 1.10.0
   qrcode-svg:
     specifier: ^1.1.0
     version: 1.1.0

--- a/src/components/icon.vue
+++ b/src/components/icon.vue
@@ -1,6 +1,6 @@
 <template>
   <svg class="umo-icon" aria-hidden="true" :width="size" :height="size">
-    <use :xlink:href="`#icon-${props.name}`" :fill="color" />
+    <use :xlink:href="`#umo-icon-${props.name}`" :fill="color" />
   </svg>
 </template>
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -41,6 +41,8 @@ export default defineConfig({
     }),
     createSvgIconsPlugin({
       iconDirs: [process.cwd() + '/src/assets/icons'],
+      symbolId: 'umo-icon-[name]',
+      customDomId: '__umo__svg__icons__dom__'
     }),
   ],
   resolve: {


### PR DESCRIPTION
如果我自己的项目引入了vite-plugin-svg-icons这个插件，然后再去引入umo-editor就会导致我原来项目的svg图标都被umo-editor的覆盖了，修复这个问题，给umo-editor的增加icon前缀