### PR TITLE
Small changes in options

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -437,8 +437,8 @@ const defaultOptions: UmoEditorOptions = {
         value: { en_US: 'Expansion', zh_CN: '扩写', ru_RU: 'Расширение' },
       },
       {
-        label: { en_US: 'Polish', zh_CN: '润色', ru_RU: 'Польский' },
-        value: { en_US: 'Polish', zh_CN: '润色', ru_RU: 'Польский' },
+        label: { en_US: 'Polish', zh_CN: '润色', ru_RU: 'Полировать' },
+        value: { en_US: 'Polish', zh_CN: '润色', ru_RU: 'Полировать' },
       },
       {
         label: { en_US: 'Proofread', zh_CN: '校阅', ru_RU: 'Корректура' },
@@ -859,6 +859,28 @@ const ojbectSchema = new ObjectSchema({
             required: false,
           },
           text: {
+            merge: 'replace',
+            validate: 'string',
+            required: false,
+          },
+        },
+      },
+      size: {
+        required: false,
+        merge: 'replace',
+        validate: 'object',
+        schema: {
+          width: {
+            merge: 'replace',
+            validate: 'number',
+            required: false,
+          },
+          height: {
+            merge: 'replace',
+            validate: 'number',
+            required: false,
+          },
+          label: {
             merge: 'replace',
             validate: 'string',
             required: false,


### PR DESCRIPTION
1. replace bad translate to correct
2. added page.size: to objectScema.
this is necessary to restore the UmoEditor state after saving some document.

Example:

```
const content = editor.getContent();
const options = editor.getPage(); // document size / width/height/margin and etc...

// sendToBackend(content, options)
```

How to restore state and content ?

```
interface MyDocument {
  options: PageOptions,
  string: PageOptions,
}
  MyDocument doc = getDocumentFromBackend(someId)
  
// restore content
editorRef.value.setContent(doc.content);

// restore page options
editorRef.value.setPage({
    size: options.size.label,
    orientation: options.orientation,
    background: options.background,
  });

// restore custom page size and other options
  editorReference.setOptions({
    page: {
      defaultMargin: {
        left: options.margin.left,
        right: options.margin.right,
        top: options.margin.top,
        bottom: options.margin.bottom,
      },
      defaultOrientation: options.orientation,
      defaultBackground: options.background,
      size: { 
        width: 250,
        height: 250,
        label: 'custom'
      },
      watermark: {
        type: options.watermark.type,
        alpha: options.watermark.alpha,
        fontColor: options.watermark.fontColor,
        fontFamily: options.watermark.fontFamily,
        fontSize: options.watermark.fontSize,
        fontWeight: options.watermark.fontWeight,
        text: options.watermark.text
      }
    },
  });
```

> I think it is necessary to add a recovery mechanism to the demo. save values ​​in localStorage, do you think it’s worth adding an example?
