### PR TITLE
粘贴插入图片时，会自动滚动到起始位置问题修复

### DIFF
--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -175,12 +175,24 @@ export const getDefaultExtensions = ({
     FileHandler.configure({
       allowedMimeTypes: file?.allowedMimeTypes,
       onPaste(editor: Editor, files: any) {
+        //记录 已有位置
+        const pageContainer = document.querySelector(
+          `${container} .umo-zoomable-container`,
+        ) as HTMLElement
+        const scrollTop = pageContainer?.scrollTop || 0
         for (const file of files) {
           editor.commands.insertFile({
             file,
             uploadFileMap: uploadFileMap.value,
             autoType: true,
           })
+        }
+        // 恢复滚动位置
+        if (pageContainer) {
+          // 使用 setTimeout 确保 DOM 更新完成后再恢复滚动位置
+          setTimeout(() => {
+            pageContainer.scrollTop = scrollTop
+          }, 0)
         }
       },
       onDrop: (editor: Editor, files: any, pos: number) => {


### PR DESCRIPTION
目前发现这种恢复的方式是验证多次后的相对好的方案，默认的focus方法 不能解决