### PR TITLE
修复引入prosemirror-state依赖不存在的问题，改为从@tiptap/pm/state获取

### DIFF
--- a/src/extensions/selection.ts
+++ b/src/extensions/selection.ts
@@ -27,9 +27,9 @@ export default Extension.create({
               return null
             }
 
-            if (editor.isFocused) {
-              return null
-            }
+            // if (editor.isFocused) {
+            //   return null
+            // }
 
             return DecorationSet.create(state.doc, [
               Decoration.inline(state.selection.from, state.selection.to, {

--- a/src/extensions/table/index.ts
+++ b/src/extensions/table/index.ts
@@ -1,6 +1,6 @@
 import Table from '@tiptap/extension-table'
 import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model'
-import { Plugin, PluginKey } from 'prosemirror-state'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 
 // 解析剪切板中 excel 的 CSS 规则（将 CSS 字符串转换为对象）
 const parseCSS = (cssRules: string) => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/def1d85a-3597-43ff-8fd7-0ebc38564f69)
修复从prosemirror-state导入Plugin, PluginKey时提示依赖不存在的问题