### PR TITLE
修复 模块““@umoteam/editor””没有导出成员“UmoEditor” 的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ vitest.config.ts.timestamp*
 # Auto Imports
 types/imports.d.ts
 types/components.d.ts
+types/src/*
 
 # Lock files
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "files": [
     "dist",
-    "types/index.d.ts"
+    "types/index.d.ts",
+    "types/src/*"
   ],
   "exports": {
     ".": {
@@ -186,6 +187,7 @@
     "unplugin-vue-components": "^0.27.4",
     "unplugin-vue-macros": "^2.11.11",
     "vite": "^4.5.3",
+    "vite-plugin-dts": "^4.5.4",
     "vite-plugin-inspect": "^0.8.7",
     "vite-plugin-svg-icons": "^2.0.1",
     "vite-tsconfig-paths": "^5.0.1",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,12 +1,12 @@
 import 'virtual:svg-icons-register'
-
 import UmoEditor from './index.vue'
 import UmoMenuButton from './menus/button.vue'
 import UmoDialog from './modal.vue'
 import UmoTooltip from './tooltip.vue'
+import type { UmoEditorOptions } from '@/types'
 
 const useUmoEditor = {
-  install: (app: any, options: any) => {
+  install: (app: any, options: UmoEditorOptions) => {
     app.provide('defaultOptions', options)
     app.component(UmoEditor.name ?? 'UmoEditor', UmoEditor)
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,6 @@ const app = createApp(App)
 
 const options = {}
 
-app.use(useUmoEditor, options as unknown as UmoEditorOptions)
+app.use(useUmoEditor, options as UmoEditorOptions)
 
 app.mount('#app')

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -1,12 +1,16 @@
 import { isRecord } from '@tool-belt/type-predicates'
 
 import { defaultOptions, ojbectSchema } from '@/options'
+import type { UmoEditorOptions } from '@/types'
 
-export const getOpitons = (propsOptions: unknown, globalOptions?: unknown) => {
+export const getOpitons = <T extends MaybeRef<UmoEditorOptions>>(
+  propsOptions: T,
+  globalOptions?: unknown,
+) => {
   const propsOptionsValue =
     isRecord(propsOptions) && Object.keys(propsOptions).includes('value')
-      ? propsOptions.value
-      : propsOptions
+      ? (propsOptions.value as UmoEditorOptions)
+      : (propsOptions as UmoEditorOptions)
 
   const componentOptions = Object.keys(propsOptionsValue).reduce<
     Record<string, unknown>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import type { Extension } from '@tiptap/core'
+import type { Extension, HTMLContent, JSONContent } from '@tiptap/core'
 import type { AsyncFunction } from '@tool-belt/type-predicates'
 
 export type SupportedLocale = 'en-US' | 'zh-CN' | 'ru-RU'
@@ -202,6 +202,20 @@ export interface FileOptions {
   }[]
 }
 
+export type GetContentFunction = <T extends 'html' | 'json' | 'text'>(
+  format: T,
+) => T extends 'html' ? HTMLContent : T extends 'json' ? JSONContent : string
+
+type OnSaveFunction = (
+  content: {
+    html: HTMLContent
+    json: JSONContent
+    text: string
+  },
+  page: PageOption,
+  document: DocumentOptions,
+) => Promise<unknown>
+
 export interface UmoEditorOptions {
   editorKey?: string
   locale?: SupportedLocale
@@ -233,10 +247,10 @@ export interface UmoEditorOptions {
   users?: UserItem[]
   extensions?: Extension[]
   translations?: Record<string, unknown>
-  onSave?: AsyncFunction
+  onSave?: OnSaveFunction
   onFileUpload?: (file: File) => Promise<{ id: string; url: string }>
   onFileDelete?: CallableFunction
 }
 
 // 组件类型声明
-export * from '../dist/umo-editor'
+export * from './src/components'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,9 +4,10 @@ import AutoImport from 'unplugin-auto-import/vite'
 import { TDesignResolver } from 'unplugin-vue-components/resolvers'
 import Components from 'unplugin-vue-components/vite'
 import VueMacros from 'unplugin-vue-macros/vite'
-import { defineConfig } from 'vite'
+import { build, defineConfig } from 'vite'
 import { createSvgIconsPlugin } from 'vite-plugin-svg-icons'
 import tsConfigPaths from 'vite-tsconfig-paths'
+import dts from 'vite-plugin-dts'
 
 import pkg from './package.json'
 import copyright from './src/utils/copyright'
@@ -83,6 +84,20 @@ export default defineConfig({
   base: '/umo-editor',
   plugins: [
     tsConfigPaths(),
+    dts({
+      outDir: 'types',
+      include: [
+        'src/components/{index,modal,tooltip}.{ts,vue}',
+        'src/components/menus/button.vue',
+      ],
+      bundledPackages: ['vue', '@tiptap/vue-3'],
+      exclude: ['src/extensions/**/*'],
+      logLevel: 'silent',
+      compilerOptions: {
+        skipDiagnostics: false,
+        logDiagnostics: true,
+      },
+    }),
     ReactivityTransform(),
     ...Object.values(vuePlugins),
   ],


### PR DESCRIPTION
修复 模块““@umoteam/editor””没有导出成员“UmoEditor” 的问题

- 安装使用 vite-plugin-dts 生成 TypeScript 的类型声明文件
- 修复 onSave 在 TS 使用中的提示

Fix the problem that the module "@ umoteam/editor" does not export the member "UmoEditor"

- Install the type declaration file that uses the vite-plugin-dts generation TypeScript
- Fix onSave hints in TS usage

![image](https://github.com/user-attachments/assets/6ee301bd-e424-4ad5-837a-939ed900b3bb)
