### PR TITLE
refactor(editor): 优化TS函数签名

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,8 +8,8 @@ import UmoDialog from './modal.vue'
 import UmoTooltip from './tooltip.vue'
 
 const useUmoEditor = {
-  install: (app: any, options: UmoEditorOptions) => {
-    app.provide('defaultOptions', options)
+  install: (app: any, options?: Partial<UmoEditorOptions>) => {
+    app.provide('defaultOptions', options ?? {})
     app.component(UmoEditor.name ?? 'UmoEditor', UmoEditor)
   },
 }

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -9,6 +9,8 @@ import {
 } from '@tool-belt/type-predicates'
 
 import type {
+  AssistantContent,
+  AssistantPayload,
   Emoji,
   GraphicSymbol,
   LineHeight,
@@ -704,7 +706,12 @@ const ojbectSchema = new ObjectSchema({
           },
           onMessage: {
             merge: 'replace',
-            validate(value: AsyncFunction) {
+            validate(
+              value: (
+                payload: AssistantPayload,
+                content: AssistantContent,
+              ) => Promise<ReadableStream | string>,
+            ) {
               if (!isAsyncFunction(value)) {
                 throw new Error('Key "onMessage" must be a async function.')
               }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,6 @@
 import type { Extension, HTMLContent, JSONContent } from '@tiptap/core'
 import type { FocusPosition } from '@tiptap/core'
 import { Fragment, Node as ProseMirrorNode } from '@tiptap/pm/model'
-import type { AsyncFunction } from '@tool-belt/type-predicates'
 
 export type SupportedLocale = 'en-US' | 'zh-CN'
 export type LayoutOption = 'web' | 'page'
@@ -148,7 +147,10 @@ export interface AssistantOptions {
   enabled?: boolean
   maxlength?: number
   commands?: CommandItem[]
-  onMessage?: AsyncFunction
+  onMessage?: (
+    payload: AssistantPayload,
+    content: AssistantContent,
+  ) => Promise<ReadableStream | string>
 }
 
 export interface EchartsOptions {
@@ -184,9 +186,9 @@ export interface AssistantPayload {
 }
 
 export interface AssistantContent {
-  html?: string
-  text?: string
-  json?: unknown
+  html: HTMLContent
+  json: JSONContent
+  text: string
 }
 export interface AssistantResult {
   prompt?: string
@@ -262,7 +264,7 @@ export interface UmoEditorOptions {
   translations?: Record<string, unknown>
   onSave?: OnSaveFunction
   onFileUpload?: (file: File) => Promise<{ id: string; url: string }>
-  onFileDelete?: CallableFunction
+  onFileDelete?: (id: string, url: string) => void
 }
 
 // 组件类型声明


### PR DESCRIPTION
- 使编辑器安装方法的options参数变为可选并提供默认空对象
- 完善AssistantOptions中onMessage的类型定义，明确参数和返回值
- 更新AssistantContent类型定义，使字段变为必填
- 修改onFileDelete类型为具体函数签名