### PR TITLE
feat(文件处理): 增强文件删除功能并支持转换标记，尝试修复 #381 ，#387.

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -113,8 +113,8 @@ const options = $ref({
       size: file.size,
     }
   },
-  onFileDelete(id: string, url: string) {
-    console.log(id, url)
+  onFileDelete(id: string, url: string, type: string) {
+    console.log(id, url, type)
   },
 })
 </script>

--- a/src/components/menus/bubble/image/convert.vue
+++ b/src/components/menus/bubble/image/convert.vue
@@ -26,7 +26,7 @@ const convertPosition = () => {
     const imageData = image.attrs ?? {}
     if (!imageData.error && imageData.src) {
       // 1.删除原有节点
-      editor.value?.chain().focus().deleteSelectionNode().run()
+      editor.value?.chain().focus().deleteSelectionNode().setMeta('convert',true).run()
       // 2.插入新的节点
       if (typeName === 'inlineImage') {
         editor.value

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -230,6 +230,8 @@ type OnSaveFunction = (
   document: DocumentOptions,
 ) => Promise<unknown>
 
+type DeleteFileType = 'image' | 'video' | 'audio' | 'file' | 'inlineImage'
+
 export interface UmoEditorOptions {
   editorKey?: string
   locale?: SupportedLocale
@@ -265,7 +267,7 @@ export interface UmoEditorOptions {
   translations?: Record<string, unknown>
   onSave?: OnSaveFunction
   onFileUpload?: (file: File) => Promise<{ id: string; url: string }>
-  onFileDelete?: (id: string, url: string) => void
+  onFileDelete?: (id: string, url: string, type?: DeleteFileType) => void
 }
 
 // 组件类型声明


### PR DESCRIPTION
- feat：在onFileDelete回调中新增文件类型参数
- feat：添加DeleteFileType类型定义
- fix: 在文件删除逻辑中增加转换标记检查  #381 
- fix：处理行内图片节点的删除情况 #387

关于 #381 没有测出“图片的“转为文件”和文件的“预览文件”两个按钮会执行onFileDelete方法” 但是测出转换行内会图片会触发 “onFileDelete” 并且修复
关于 #387 检查发现行内图片删除没有触发删除