### PR TITLE
fix: 修复空行插入标题块时行高丢失问题

### DIFF
--- a/src/assets/styles/editor.less
+++ b/src/assets/styles/editor.less
@@ -224,6 +224,10 @@
       line-height: 1;
     }
 
+    &:is(h1, h2, h3, h4, h5, h6)::after {
+      line-height: inherit;
+    }
+
     &:first-child {
       >*:not(table) {
         display: none;
@@ -963,6 +967,16 @@
 
   h6 {
     font-size: 0.85em;
+  }
+
+  h1[data-placeholder],
+  h2[data-placeholder],
+  h3[data-placeholder],
+  h4[data-placeholder],
+  h5[data-placeholder],
+  h6[data-placeholder] {
+    min-height: 1em;
+    min-height: 1lh;
   }
 }
 


### PR DESCRIPTION
## Bug 描述

在编辑器中，当光标位于一个空行时，通过工具栏插入/切换为 Header 块，例如 Header 1 或 Header 2，当前插入的标题块会丢失原本应有的行高样式。

从截图可以看到，空行被转换为标题块后，该行的可编辑区域高度明显异常：标题块所在位置只剩下一条很窄的横向区域，未按照 Header 1 / Header 2 的正常块级高度渲染，导致占位文本和光标区域显示不完整，视觉上像是该块的 line-height 或块高度没有被正确继承/应用。

## 复现步骤

1. 打开 Umo Editor。
2. 在文档中插入一个空行，或将光标移动到已有空白段落。
3. 点击工具栏中的 `标题 1` / `标题 2`，将当前空行转换为 Header 块。
4. 观察当前插入的 Header 块显示效果。
<img width="1552" height="1289" alt="image" src="https://github.com/user-attachments/assets/b59b6db0-2e3d-49c7-8ff4-5fd24cbad37d" />

## 实际结果

当前 Header 块的行高丢失，块高度异常收缩，空行位置显示为一条很窄的横线/浅色区域，无法呈现正常标题块高度。

## 期望结果

当空行被转换为 Header 1 / Header 2 后，该块应正确应用对应标题样式，包括字体大小、行高、上下间距或最小高度，使光标、占位文本和内容区域正常显示。

## 影响

该问题会导致用户在空行处插入标题时出现明显的排版异常，影响编辑体验，也可能让用户误以为标题插入失败。