### PR TITLE
fix(i18n): 补全文件相关文案并修正超限提示 key

### DIFF
--- a/src/components/dialog/signature.vue
+++ b/src/components/dialog/signature.vue
@@ -237,7 +237,7 @@ const selectedImageDimensionText = computed(() =>
 )
 
 const getFileSizeLimitMessage = (file) =>
-  t('file.limitSize', {
+  t('file.limit', {
     filename: file?.name || t('file.unknownName'),
     size: Math.ceil(uploadMaxSize.value / 1024 / 1024),
   })

--- a/src/components/dialog/stamp.vue
+++ b/src/components/dialog/stamp.vue
@@ -188,7 +188,7 @@ const submitPresetSize = computed(() =>
 )
 
 const getFileSizeLimitMessage = (file) =>
-  t('file.limitSize', {
+  t('file.limit', {
     filename: file?.name || t('file.unknownName'),
     size: Math.ceil(uploadMaxSize.value / 1024 / 1024),
   })

--- a/src/extensions/file/index.js
+++ b/src/extensions/file/index.js
@@ -133,7 +133,7 @@ export default Node.create({
           if (maxSize !== 0 && size > maxSize) {
             useMessage('error', {
               attach: editor.storage.container,
-              content: t('file.limitSize', {
+              content: t('file.limit', {
                 filename: file.name,
                 size: maxSize / 1024 / 1024,
               }),

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -802,8 +802,11 @@
   },
   "file": {
     "uploading": "Uploading file...",
+    "preview": "Preview File",
     "download": "Download File",
     "limit": "File \"{filename}\" exceeds the limit of {size}MB",
+    "unknownName": "Unknown Name",
+    "unknownSize": "Unknown Size",
     "notAllow": {
       "title": "Error Message",
       "message": "Insertion of this file type is not allowed in the current document."

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -667,8 +667,11 @@
   },
   "file": {
     "uploading": "Caricamento file...",
+    "preview": "Anteprima file",
     "download": "Scarica file",
     "limit": "Il file \"{filename}\" supera il limite di {size}MB",
+    "unknownName": "Nome sconosciuto",
+    "unknownSize": "Dimensione sconosciuta",
     "notAllow": {
       "title": "Messaggio di errore",
       "message": "L'inserimento di questo tipo di file non è consentito nel documento corrente."


### PR DESCRIPTION
## Summary
- 英文 / 意大利语界面下，文件节点预览按钮 tooltip 会回退显示中文「预览文件」，原因是 `en-US`、`it-IT` 缺少 `file.preview`、`file.unknownName`、`file.unknownSize`
- 文件超限提示使用了不存在的 key `file.limitSize`，语言包实际为 `file.limit`，导致超大文件提示异常

## Changes
- 补全 `en-US.json`、`it-IT.json` 中缺失的文件相关词条
- 将 `file.limitSize` 统一改为 `file.limit`（文件插入、签名、印章上传）

## Test plan
- [ ] 切换到 English，插入可预览文件（如 PDF），悬停眼睛图标，tooltip 应为 `Preview File` 而非中文
- [ ] 切换到 English，插入超过 `maxSize` 的文件，应显示正确的英文超限提示
- [ ] 中文界面下，预览 tooltip 与超限提示行为保持不变